### PR TITLE
Fix compatibility issues

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Aigei Audio Downloader",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Tự động bắt và tải file âm thanh từ aigei.com",
   
   "permissions": [


### PR DESCRIPTION
## Summary
- fix runtime messaging callback handling
- close tabs using callback-based API to work on older Chrome
- bump extension version to 1.1

## Testing
- `bash check_ready.sh`


------
https://chatgpt.com/codex/tasks/task_b_68651b252dd4832e9e9072518f1c8b03